### PR TITLE
allow to override kernel directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 obj-m += i2c-ch341.o
 
+KERNEL_DIR := /lib/modules/$(shell uname -r)/build
+
 all:
-		make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+		make -C $(KERNEL_DIR) M=$(PWD) modules
 
 clean:
-		make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+		make -C $(KERNEL_DIR) M=$(PWD) clean
 
 reload:	all
 		sudo rmmod i2c-ch341 ||true
-		sudo insmod ./i2c-ch341.ko 
+		sudo insmod ./i2c-ch341.ko


### PR DESCRIPTION
Kernel directory override is used by DKMS to build module for newly installed kernel while older kernel is running.